### PR TITLE
Notification chunk

### DIFF
--- a/pzbot.py
+++ b/pzbot.py
@@ -92,6 +92,7 @@ async def getalldeaths(ctx):
                     else:
                         deathdict[player] = 1
     rstring = ""
+    deathdict = dict(reversed(sorted(deathdict.items(), key=lambda item: item[1])))
     for x in deathdict:
         p = x
         c = deathdict[x]
@@ -159,6 +160,10 @@ async def rcon_command(ctx, command):
     print(r)
     return r
 
+async def chunks(lst, n):
+    """Yield successive n-sized chunks from lst."""
+    for i in range(0, len(lst), n):
+        yield lst[i:i + n]
 
 
 async def IsChannelAllowed(ctx):
@@ -171,7 +176,7 @@ async def IsChannelAllowed(ctx):
         raise Exception("Not allowed to operate in channel")
 
 class AdminCommands(commands.Cog):
-    """Moderator Server Commands"""
+    """Admin Server Commands"""
 
     @commands.command(pass_context=True)
     async def pzsetaccess(self, ctx):
@@ -464,8 +469,11 @@ class UserCommands(commands.Cog):
         cmd_split = ctx.message.content.split()
         option_find = ""
         dc = await getalldeaths(ctx)
-        results = dc
-        await ctx.send(results)
+        results = dc.split('\n')
+        clist = chunks(results, 500) 
+        async for c in clist: 
+            print(len(dc))
+            await ctx.send('\n'.join(c))
 
 
     @commands.command(pass_context=True)

--- a/pzbot.py
+++ b/pzbot.py
@@ -470,7 +470,7 @@ class UserCommands(commands.Cog):
         option_find = ""
         dc = await getalldeaths(ctx)
         results = dc.split('\n')
-        clist = chunks(results, 500) 
+        clist = chunks(results, 100) 
         async for c in clist: 
             print(len(dc))
             await ctx.send('\n'.join(c))

--- a/pzwatcher.py
+++ b/pzwatcher.py
@@ -73,7 +73,7 @@ async def PlayerCheck(lfile, channel):
                 if "removed connection index" in l:
                     user = ls[3].strip('"')
                     player_notif[user] = 0
-                        await channel.send(f"{user} has disconnected!")
+                    await channel.send(f"{user} has disconnected!")
                     break
                 if "fully connected (" in l:
                     user = ls[3].strip('"')

--- a/pzwatcher.py
+++ b/pzwatcher.py
@@ -24,6 +24,7 @@ from subprocess import Popen
 import glob
 import subprocess
 from file_read_backwards import FileReadBackwards
+import datetime
 # Setup environment
 load_dotenv()
 TOKEN = os.getenv('DISCORD_TOKEN')
@@ -57,30 +58,34 @@ async def logwatcher():
             player_check = await PlayerCheck(x, nchannel)
 
 
+
+player_notif = {}
 async def PlayerCheck(lfile, channel):
     count = 0
     try:
         with FileReadBackwards(lfile) as frb:
             for l in frb:
-                print(l)
-                ls = l.split()
                 if "disconnected player" in l:
-                    print("at dc")
-                    print(l)
+                    if count == 0:
+                        count += 1
+                        continue
+                ls = l.split()
+                if "removed connection index" in l:
                     user = ls[3].strip('"')
-                    await channel.send(f"{user} has disconnected!")
+                    player_notif[user] = 0
+                        await channel.send(f"{user} has disconnected!")
                     break
-                if "fully connected" in l:
-                    print("Connected")
-                    print(l)
+                if "fully connected (" in l:
                     user = ls[3].strip('"')
-                    await channel.send(f"{user} has joined!")
+                    if player_notif.get(user, 0) < 1:
+                        await channel.send(f"{user} has joined!")
+                    else:
+                        player_notif[user] -= 1
+
                     break
                 if "died at (" in l:
-                    print("At Died")
-                    print(l)
-
                     user = ls[3].strip('"')
+                    player_notif[user] = 1
                     await channel.send(f"{user} has died!")
                     break
                 break


### PR DESCRIPTION
#11 Chunked player death chart to 100 player chunks to prevent going over discord word limits, also reverse sorted the death list
#13 Fixed excess notifications by tracking player deaths/dc's in a dict, deaths = 2 extra notifications, and they are reset down on rejoin. 