### PR TITLE
Pzrestart

### DIFF
--- a/pzbot.py
+++ b/pzbot.py
@@ -151,7 +151,7 @@ async def restart_server(ctx):
         d = await rcon_command(ctx, [f"players"])
         if "connect: connection refused" in d:
             server_down = True
-        await asyncio.sleep(3)
+        await asyncio.sleep(5)
     
     if os.name == 'nt':
         terminate_zom = '''wmic PROCESS where "name like '%java.exe%' AND CommandLine like '%zomboid.steam%'" Call Terminate'''


### PR DESCRIPTION
#17 
Added a more graceful restart using 'quit' rcon command, it then waits for rcon to time out, then begins the full shutdown process. 
Also fixed invalid var references
Added RCON_PATH to .env, as I noticed RCON was hard coded to UNIX based pathing. Default is now './' relative path for where your rcon command is located.